### PR TITLE
Adiciona 0 à esquerda do CRC16 caso ele seja numérico e inicie com 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,11 @@ Para facilitar a implementação do payload Pix, segue abaixo o método de cálc
           }
       }
 
-      //RETORNA CÓDIGO CRC16 DE 4 CARACTERES
-      return self::ID_CRC16.'04'.strtoupper(dechex($resultado));
+      $hex = strtoupper(dechex($resultado));
+      $hex = str_pad( $hex, 4, '0', STR_PAD_LEFT ); // se o hex for numerico iniciando em 0, precisamos garantir que ele fique com 4 caracteres
+
+      //RETORNA CODIGO CRC16 DE 4 CARACTERES
+      return self::ID_CRC16.'04'.$hex;
   }
 ```
 ___________________


### PR DESCRIPTION
Oi, William! 

Muito obrigado pelo tutorial, ajudou demais!!!

Encontrei um bug na geração do CRC16, quando o resultado dele é numérico iniciando em zero a função considera um número e remove o zero. Então antes de retornar o resultado fiz forçar o tamanho de 4 caracteres adicionando zeros à esquerda quando necessário.

Obrigado!